### PR TITLE
added luxon library, formatted event to mm/dd/yyyy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6850,6 +6850,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "luxon": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.3.3.tgz",
+      "integrity": "sha512-3CM0jpS3mbHwWoPYprX1/Zsd5esni0LkhMfSiSY6xQ3/M3pnct3OPWbWkQdEEl9MO9593k6PvDn1DhxCkpuZEw=="
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^1.4.2",
     "@material-ui/icons": "^2.0.0",
     "history": "^4.7.2",
+    "luxon": "^1.3.3",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",

--- a/src/components/GenericCard.js
+++ b/src/components/GenericCard.js
@@ -6,6 +6,7 @@ import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
+import { DateTime } from 'luxon';
 
 import '../Styles/_GenericCard.css'
 
@@ -29,10 +30,10 @@ class GeneralCard extends React.Component {
                 Event type: { thisEvent.type }
             </Typography>
             <Typography component="p">
-                Event begin: { thisEvent.begin }
+                Event begin: { DateTime.fromObject(thisEvent.begin).toLocaleString() }
             </Typography>
             <Typography component="p">
-                Event end: { thisEvent.end }
+                Event end: { DateTime.fromObject(thisEvent.end).toLocaleString() }
             </Typography>
         </div>
       )


### PR DESCRIPTION
Hi @GavinThomas1192 @ChadChapman I installed bare minimum for luxon and formatted the event date to simple mm/dd/yyyy since there was no real time value associated with the input. I did not install the full-icu bells & whistles with luxon because seems like we just need it for simple formatting, but we can always add that in the future if desired. Thanks again Gavin for the luxon recommendation. 